### PR TITLE
add option to skip git pull

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ The `build.sh` command provides several options that allows to build part of Xat
 - `--library=<library directory name>`: build the `<library directory name>` library. The provided name must match exactly the name of the library directory located in `xatkit-dev/src/libraries`
 - `--skip-tests`: skip the test execution (similar to maven's `-DskipTests`)
 - `--product`: create a *product* version of the bundled artifacts. This option installs the built platforms in `xatkit-dev/build/plugins`, allowing the runtime component to use them. Installed platforms can also be imported in the Eclipse editors.
+- `--skip-pull`: skip the git pull for all repositories during build
 
 *XDK Tip: rebuild single platforms*
 

--- a/build.sh
+++ b/build.sh
@@ -23,6 +23,8 @@
 #						zipped update-site is created in /update-site
 # --skip-tests:			skip the build tests (equivalent to -DskipTests parameter for maven)
 # --skip-mvn:			skip maven build. This can be combined with --product to refresh the content of the build/ directory
+# --skip-pull:			skip git pull. This can be used to build your platform without downloading any new changes from the 
+#						repos so your environment can remain unchanged when you build the platform.
 #
 # Examples
 #
@@ -40,8 +42,11 @@ build_platform() {
 	platform=$1
 	platform_name=${platform%"-platform"}
 	cd $XATKIT_DEV/src/platforms/$platform
-	echo "Pulling $platform"
-	git pull
+	if [ $skip_pull = false ] 
+	then
+		echo "Pulling $platform"
+		git pull
+	fi
 
 	echo "Building $platform"
 	if [ $skip_mvn = false ]
@@ -63,8 +68,11 @@ build_library() {
 	library=$1
 	library_name=${library%"-library"}
 	cd $XATKIT_DEV/src/libraries/$library
-	echo "Pulling $library"
-	git pull
+	if [ $skip_pull = false ] 
+	then	
+		echo "Pulling $library"
+		git pull
+	fi
 
 	echo "Building $library"
 	if [ $skip_mvn = false ]
@@ -102,6 +110,7 @@ build_runtime=false
 build_product=false
 build_eclipse=false
 skip_mvn=false
+skip_pull=false
 all_platforms=$(ls -d src/platforms/* | xargs -n 1 basename)
 all_libraries=$(ls -d src/libraries/* | xargs -n 1 basename)
 platforms_to_build=()
@@ -142,6 +151,7 @@ do
 		"--skip-tests") 	mvn_options="$mvn_options -DskipTests" ;;
 		"--skip-mvn")		skip_mvn=true ;;
 		"--product")		mvn_options="$mvn_options -Pbuild-product"; build_product=true ;;
+		"--skip-pull") 		skip_pull=true ;;
 		*) 					echo "Unknown argument $arg"; exit 1
 	esac
 done
@@ -185,8 +195,11 @@ cd $XATKIT_DEV
 
 # Install the top-level pom (always needs to be done)
 cd $XATKIT_DEV/src/xatkit-releases
-echo "Pulling Xatkit Releases"
-git pull
+if [ $skip_pull = false ] 
+then
+	echo "Pulling Xatkit Releases"
+	git pull
+fi
 echo "Building Xatkit Releases"
 if [ $skip_mvn = false ] 
 then
@@ -199,8 +212,11 @@ if [ $build_metamodels = true ]
 then
 	cd $XATKIT_DEV/src/xatkit-metamodels
 
-	echo "Pulling Xatkit Metamodels"
-	git pull
+	if [ $skip_pull = false ] 
+	then
+		echo "Pulling Xatkit Metamodels"
+		git pull
+	fi
 	echo "Building Xatkit Metamodels"
 	if [ $skip_mvn = false ] 
 	then
@@ -213,8 +229,11 @@ if [ $build_runtime = true ]
 then
 	cd $XATKIT_DEV/src/xatkit-runtime
 
-	echo "Pulling Xatkit Runtime"
-	git pull
+	if [ $skip_pull = false ] 
+	then
+		echo "Pulling Xatkit Runtime"
+		git pull
+	fi
 	echo "Building Xatkit Runtime"
 	if [ $skip_mvn = false ]
 	then
@@ -232,8 +251,12 @@ fi
 if [ $build_eclipse = true ]
 then
 	cd $XATKIT_DEV/src/xatkit-eclipse
-	echo "Pulling Xatkit Eclipse Plugins"
-	git pull
+	
+	if [ $skip_pull = false ] 
+	then
+		echo "Pulling Xatkit Eclipse Plugins"
+		git pull
+	fi
 	echo "Building Xatkit Eclipse Plugins"
 	if [ $skip_mvn = false ]
 	then
@@ -303,9 +326,12 @@ then
 		echo "Copying $script"
 		cp $script $XATKIT_DEV/build/bin/
 	done
-	echo "Pulling Xatkit Examples"
-	cd $XATKIT_DEV/src/xatkit-examples
-	git pull
+	if [ $skip_pull = false ] 
+	then
+		echo "Pulling Xatkit Examples"
+		cd $XATKIT_DEV/src/xatkit-examples
+		git pull
+	fi
 	echo "Copying Xatkit Examples"
 	cp -r $XATKIT_DEV/src/xatkit-examples $XATKIT_DEV/build/examples
 	rm -rf $XATKIT_DEV/build/examples/.git


### PR DESCRIPTION
This option will allow developers to use the build script without having all repos automatically pulled.

Since changes are being done very regularly, this will prevent that any changes introduced to the other repos (mainly runtime) impact in the build process.